### PR TITLE
Fix for aes_encrypt() conflict with built-in function on ESP8266 and ESP32

### DIFF
--- a/aes/ideetron/AES-128_V10.cpp
+++ b/aes/ideetron/AES-128_V10.cpp
@@ -35,7 +35,7 @@
 // This file was taken from
 // https://github.com/Ideetron/RFM95W_Nexus/tree/master/LoRaWAN_V31 for
 // use with LMIC. It was only cosmetically modified:
-//  - AES_Encrypt was renamed to aes_encrypt.
+//  - AES_Encrypt was renamed to lmic_aes_encrypt.
 //  - All other functions and variables were made static
 //  - Tabs were converted to 2 spaces
 //  - An #include and #if guard was added
@@ -72,7 +72,7 @@ static CONST_TABLE(unsigned char, S_Table)[16][16] = {
   {0x8C,0xA1,0x89,0x0D,0xBF,0xE6,0x42,0x68,0x41,0x99,0x2D,0x0F,0xB0,0x54,0xBB,0x16}
 };
 
-extern "C" void aes_encrypt(unsigned char *Data, unsigned char *Key);
+extern "C" void lmic_aes_encrypt(unsigned char *Data, unsigned char *Key);
 static void AES_Add_Round_Key(unsigned char *Round_Key);
 static unsigned char AES_Sub_Byte(unsigned char Byte);
 static void AES_Shift_Rows();
@@ -88,7 +88,7 @@ static void Send_State();
 *               *Key    Key to encrypt data with is a 16 byte long arry
 *****************************************************************************************
 */
-void aes_encrypt(unsigned char *Data, unsigned char *Key)
+void lmic_aes_encrypt(unsigned char *Data, unsigned char *Key)
 {
   unsigned char i;
   unsigned char Row,Collum;

--- a/aes/other.c
+++ b/aes/other.c
@@ -21,7 +21,7 @@
  * implementation. This file assumes that there is an encryption
  * function available with this signature:
  *
- *      extern "C" void aes_encrypt(u1_t *data, u1_t *key);
+ *      extern "C" void lmic_aes_encrypt(u1_t *data, u1_t *key);
  *
  *  That takes a single 16-byte buffer and encrypts it wit the given
  *  16-byte key.
@@ -32,7 +32,7 @@
 #if !defined(USE_ORIGINAL_AES)
 
 // This should be defined elsewhere
-void aes_encrypt(u1_t *data, u1_t *key);
+void lmic_aes_encrypt(u1_t *data, u1_t *key);
 
 // global area for passing parameters (aux, key) and for storing round keys
 u4_t AESAUX[16/sizeof(u4_t)];
@@ -55,7 +55,7 @@ static void shift_left(u1_t *buf, u1_t len) {
 // in any case. The CMAC result is returned in AESAUX as well.
 static void os_aes_cmac(u1_t *buf, u2_t len, u1_t prepend_aux) {
     if (prepend_aux)
-        aes_encrypt(AESaux, AESkey);
+        lmic_aes_encrypt(AESaux, AESkey);
     else
         memset (AESaux, 0, 16);
 
@@ -79,7 +79,7 @@ static void os_aes_cmac(u1_t *buf, u2_t len, u1_t prepend_aux) {
             // shifts and xor on that.
             u1_t final_key[16];
             memset(final_key, 0, sizeof(final_key));
-            aes_encrypt(final_key, AESkey);
+            lmic_aes_encrypt(final_key, AESkey);
 
             // Calculate K1
             u1_t msb = final_key[0] & 0x80;
@@ -100,7 +100,7 @@ static void os_aes_cmac(u1_t *buf, u2_t len, u1_t prepend_aux) {
                 AESaux[i] ^= final_key[i];
         }
 
-        aes_encrypt(AESaux, AESkey);
+        lmic_aes_encrypt(AESaux, AESkey);
     }
 }
 
@@ -112,7 +112,7 @@ static void os_aes_ctr (u1_t *buf, u2_t len) {
     while (len) {
         // Encrypt the counter block with the selected key
         memcpy(ctr, AESaux, sizeof(ctr));
-        aes_encrypt(ctr, AESkey);
+        lmic_aes_encrypt(ctr, AESkey);
 
         // Xor the payload with the resulting ciphertext
         for (u1_t i = 0; i < 16 && len > 0; i++, len--, buf++)
@@ -132,7 +132,7 @@ u4_t os_aes (u1_t mode, u1_t *buf, u2_t len) {
         case AES_ENC:
             // TODO: Check / handle when len is not a multiple of 16
             for (u1_t i = 0; i < len; i += 16)
-                aes_encrypt(buf+i, AESkey);
+                lmic_aes_encrypt(buf+i, AESkey);
             break;
 
         case AES_CTR:


### PR DESCRIPTION
This issue is a 'comeback' from year 2016. It was fixed in LMIC but still remains in BASICMAC.
Details are:
* https://github.com/matthijskooijman/arduino-lmic/issues/24/ and
* https://github.com/matthijskooijman/arduino-lmic/commit/e9ae35136beae545fded5831ae98a962e00f2e12#diff-16b9479e2c4b7ec030c4233f27bf6344