### PR TITLE
initialize MCU GPIO pin assigned to SX126x BUSY signal

### DIFF
--- a/target/arduino/hal/hal.cpp
+++ b/target/arduino/hal/hal.cpp
@@ -60,6 +60,8 @@ static void hal_io_init () {
         pinMode(lmic_pins.rx, OUTPUT);
     if (lmic_pins.rst != LMIC_UNUSED_PIN)
         pinMode(lmic_pins.rst, OUTPUT);
+    if (lmic_pins.busy != LMIC_UNUSED_PIN)
+        pinMode(lmic_pins.busy, INPUT);
     if (lmic_pins.tcxo != LMIC_UNUSED_PIN)
         pinMode(lmic_pins.tcxo, OUTPUT);
 


### PR DESCRIPTION
When a pin on ESP8266/ESP32 is not initialized as digital INPUT - subsequent  digitalRead() operations always return 'zero' value.
This breaks normal function of _hal_pin_busy_wait_() procedure - at first, then every COMMAND operation - at next. 