### PR TITLE
Added ARDUINO_TTGO_LoRa32_V1 board and script for Windows environment

### DIFF
--- a/lmic/radio-sx127x.c
+++ b/lmic/radio-sx127x.c
@@ -411,7 +411,7 @@ static void configLoraModem (bool txcont) {
     // set ModemConfig1 'bbbbccch' (bw=xxxx, cr=xxx, implicitheader=x)
     writeReg(LORARegModemConfig1,
              ((getBw(LMIC.rps) - BW125 + 7) << 4) | // BW125 --> 7
-             ((getCr(LMIC.rps) - CR4_5 + 1) << 1) | // CR_4_5 --> 1
+             ((getCr(LMIC.rps) - CR_4_5 + 1) << 1) | // CR_4_5 --> 1
              (getIh(LMIC.rps) != 0));       // implicit header
 
     // set ModemConfig2 'sssstcmm' (sf=xxxx, txcont=x, rxpayloadcrc=x, symtimeoutmsb=00)

--- a/target/arduino/examples-common-files/standard-pinmaps.ino
+++ b/target/arduino/examples-common-files/standard-pinmaps.ino
@@ -87,6 +87,22 @@ const lmic_pinmap lmic_pins = {
     // TCXO is controlled through DIO3 by the SX1262 directly
     .tcxo = LMIC_UNUSED_PIN,
 };
+#elif defined(ARDUINO_TTGO_LoRa32_V1)
+#if !defined(BRD_sx1276_radio)
+#error "Wrong radio defined for this board (fix in BasicMAC target-config.h)"
+#endif
+// Assume this is a Nexus board
+const lmic_pinmap lmic_pins = {
+    .nss = 18,
+    // RX/TX is controlled through RXTX by the SX1272 directly on the RFM95W
+    .tx = LMIC_UNUSED_PIN,
+    .rx = LMIC_UNUSED_PIN,
+    // RST is hardwarid to MCU reset
+    .rst = 14,
+    .dio = {26, 33, 32},
+    .busy = LMIC_UNUSED_PIN,
+    .tcxo = LMIC_UNUSED_PIN,
+};
 #else
 #error "Unknown board, no standard pimap available. Define your own in the main sketch file."
 #endif

--- a/target/arduino/export.bat
+++ b/target/arduino/export.bat
@@ -9,6 +9,7 @@
 :: \name Remko Welling (pe1mew@gmail.com)
 
 SET option=%1
+SET target_directory=%1
 SET source_directory=%~dp0
 
 :: Select operation: "-" is command, else run
@@ -40,11 +41,11 @@ GOTO :EOF
 
 :RUN
 :: Normal operation.
-   IF NOT EXIST "%option:"=%" (
-      ECHO Target directory "%option:"=%" does not exist.
+   IF NOT EXIST "%target_directory:"=%" (
+      ECHO Target directory "%target_directory:"=%" does not exist.
       GOTO :EOF
    ) 
-   IF EXIST "%option:"=%\BasicMAC" (
+   IF EXIST "%target_directory:"=%\BasicMAC" (
       GOTO :DO_REMOVE
    ) ELSE (
       GOTO :DO_CREATE
@@ -53,53 +54,53 @@ GOTO :EOF
 
 :DO_REMOVE
 :: Remove existing directory, prompt for acknowledge.
-   ECHO Removing directory "%option:"=%\BasicMAC",
+   ECHO Removing directory "%target_directory:"=%\BasicMAC",
    SET /P AREYOUSURE=Are you sure (Y/[N])?
    IF /I "%AREYOUSURE%" NEQ "Y" GOTO :EOF
    
-   rmdir /s /q "%option:"=%\BasicMAC"
+   rmdir /s /q "%target_directory:"=%\BasicMAC"
 
 :DO_CREATE
 :: Create directory structure for library in target directory
-   ECHO Ceating Arduino library in: "%option:"=%"
-   IF NOT EXIST "%option:"=%\BasicMAC" (
-      md "%option:"=%\BasicMAC"
+   ECHO Ceating Arduino library in: "%target_directory:"=%"
+   IF NOT EXIST "%target_directory:"=%\BasicMAC" (
+      md "%target_directory:"=%\BasicMAC"
    )
-   IF NOT EXIST "%option:"=%\BasicMAC\src" (
-      md "%option:"=%\BasicMAC\src"
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\src" (
+      md "%target_directory:"=%\BasicMAC\src"
    )
-   IF NOT EXIST "%option:"=%\BasicMAC\src\lmic" (
-      md "%option:"=%\BasicMAC\src\lmic"
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\src\lmic" (
+      md "%target_directory:"=%\BasicMAC\src\lmic"
    )
-   IF NOT EXIST "%option:"=%\BasicMAC\src\hal" (
-      md "%option:"=%\BasicMAC\src\hal"
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\src\hal" (
+      md "%target_directory:"=%\BasicMAC\src\hal"
    )
-   IF NOT EXIST "%option:"=%\BasicMAC\src\aes" (
-      md "%option:"=%\BasicMAC\src\aes"
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\src\aes" (
+      md "%target_directory:"=%\BasicMAC\src\aes"
    )
-   IF NOT EXIST "%option:"=%\BasicMAC\examples" (
-      md "%option:"=%\BasicMAC\examples"
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\examples" (
+      md "%target_directory:"=%\BasicMAC\examples"
    )
-   IF NOT EXIST "%option:"=%\BasicMAC\examples\basicmac-abp" (
-      md "%option:"=%\BasicMAC\examples\basicmac-abp"
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\examples\basicmac-abp" (
+      md "%target_directory:"=%\BasicMAC\examples\basicmac-abp"
    )
-   IF NOT EXIST "%option:"=%\BasicMAC\examples\basicmac-otaa" (
-      md "%option:"=%\BasicMAC\examples\basicmac-otaa"
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\examples\basicmac-otaa" (
+      md "%target_directory:"=%\BasicMAC\examples\basicmac-otaa"
    )
 
 :DO_COPY
    :: Copy relevant files from git repository to Arduino Library
    @ECHO on
-   COPY "%source_directory%library.properties" "%option:"=%\BasicMAC\library.properties"
-   COPY "%source_directory%basicmac.h" "%option:"=%\BasicMAC\src"
-   COPY "%source_directory%..\..\lmic" "%option:"=%\BasicMAC\src\lmic"
-   COPY "%source_directory%hal" "%option:"=%\BasicMAC\src\hal"
-   COPY "%source_directory%..\..\aes" "%option:"=%\BasicMAC\src\aes"
-   COPY "%source_directory%examples\basicmac-otaa" "%option:"=%\BasicMAC\examples\basicmac-otaa"
-   COPY "%source_directory%examples-common-files" "%option:"=%\BasicMAC\examples\basicmac-otaa"
-   COPY "%source_directory%examples\basicmac-abp" "%option:"=%\BasicMAC\examples\basicmac-abp"
-   COPY "%source_directory%examples-common-files" "%option:"=%\BasicMAC\examples\basicmac-abp"
-   COPY "%source_directory%board.h" "%option:"=%\BasicMAC\src\lmic"
-   COPY "%source_directory%hw.h" "%option:"=%\BasicMAC\src\lmic"
+   COPY "%source_directory%library.properties" "%target_directory:"=%\BasicMAC\library.properties"
+   COPY "%source_directory%basicmac.h" "%target_directory:"=%\BasicMAC\src"
+   COPY "%source_directory%..\..\lmic" "%target_directory:"=%\BasicMAC\src\lmic"
+   COPY "%source_directory%hal" "%target_directory:"=%\BasicMAC\src\hal"
+   COPY "%source_directory%..\..\aes" "%target_directory:"=%\BasicMAC\src\aes"
+   COPY "%source_directory%examples\basicmac-otaa" "%target_directory:"=%\BasicMAC\examples\basicmac-otaa"
+   COPY "%source_directory%examples-common-files" "%target_directory:"=%\BasicMAC\examples\basicmac-otaa"
+   COPY "%source_directory%examples\basicmac-abp" "%target_directory:"=%\BasicMAC\examples\basicmac-abp"
+   COPY "%source_directory%examples-common-files" "%target_directory:"=%\BasicMAC\examples\basicmac-abp"
+   COPY "%source_directory%board.h" "%target_directory:"=%\BasicMAC\src\lmic"
+   COPY "%source_directory%hw.h" "%target_directory:"=%\BasicMAC\src\lmic"
    @ECHO off
 GOTO :EOF

--- a/target/arduino/export.bat
+++ b/target/arduino/export.bat
@@ -1,14 +1,18 @@
 @ECHO off > nul
-:: Batch file to install BasicMAC from the git repository in to an
-:: existing Arduino installation by specifying the location of the 
-:: User library directory e.g.: "C:\Users\UserName\Documents\Arduino\libraries"
+:: Batch file to install BasicMAC from the git repository in to a
+:: Arduino installation by specifying the location of the User 
+:: library directory e.g.: "C:\Users\UserName\Documents\Arduino\libraries".
+
+:: Options are: 
+::  -h  --help    Help and information.
+::  -c  --create  ^<directory^> Create Arduino library at specified location.
+::                              When a directory is found with equal name the 
+::                              user is informed and the script is aborted.
+::  -r  --replace ^<directory^> Replace Arduino library at specified location erasing existing files.
+::                              When a directory is found with equal name the 
+::                              user is requested to confirm deletion of the directory.
 
 :: \name Remko Welling (pe1mew@gmail.com)
-:: \date 8-7-2020
-:: \version 1.0
-
-:: \todo This script cannot work when whitespaces are in the directory path.
-:: As a workaround, export the library else where and move it in to the Arduino library directory.
 
 SET option=%1
 SET source_directory=%~dp0
@@ -20,70 +24,87 @@ IF ERRORLEVEL 1 CALL :DEFAULT_CASE
 
 EXIT /B
 
+:CASE_-r
+:CASE_--replace
+:: remove existing folder structure and copy new library at specified location.
+   IF EXIST "%target_directory:"=%\BasicMAC" (
+      GOTO :DO_REMOVE
+   ) ELSE (
+      ECHO [ERROR] Destination directory "%target_directory:"=%\BasicMAC" does not exist. Please correct destination name.
+   )
+GOTO :EOF
+
 :CASE_-c
 :CASE_--create
-   IF EXIST %target_directory% (
-      GOTO :COPY
+:: create the directory and copy files to it, aborting if it already exists.
+   IF EXIST "%target_directory:"=%\BasicMAC" (
+      ECHO [ERROR] Destination directory "%target_directory:"=%\BasicMAC" does exist. Please correct destination name.
    ) ELSE (
-      ECHO [ERROR] Destination directory %target_directory% does not exist. Please correct destination name.
+      GOTO :DO_CREATE
    )
 GOTO :EOF
 
 :CASE_-h
 :CASE_--help
    ECHO Create an Arduino-compatible library in the given directory, overwriting existing files.
-   ECHO -h  --help   This information.
-   ECHO -c  --create ^<directory^> Create Arduino library at specified location
+   ECHO -h  --help    This information.
+   ECHO -c  --create  ^<directory^> Create Arduino library at specified location.
+   ECHO -r  --replace ^<directory^> Replace Arduino library at specified location erasing existing files.
 GOTO :EOF
 
 :DEFAULT_CASE
-   ECHO Unknown command. Type: export.bat -h or --help for options.
+   ECHO Unknown command or abort. Type: export.bat -h or --help for options.
 GOTO :EOF
 
-:COPY
-   :: Test if target directory has a terminating back-slash
-   IF NOT "%target_directory:~-1%"=="\" (
-      ECHO [ERROR] Target directory has no terminating "\" (back-slash^). Please correct target directory accordingly.
-      GOTO :EOF
-   )
-   :: Copy all files in to the library in the target directory
-   ECHO Ceating Arduino library in: %target_directory%
-   IF NOT EXIST %target_directory%\BasicMAC (
-      md "%target_directory%\BasicMAC"
-   )
-   IF NOT EXIST %target_directory%\BasicMAC\src (
-      md "%target_directory%\BasicMAC\src"
-   )
-   IF NOT EXIST %target_directory%\BasicMAC\src\lmic (
-      md "%target_directory%\BasicMAC\src\lmic"
-   )
-   IF NOT EXIST %target_directory%\BasicMAC\src\hal (
-      md "%target_directory%\BasicMAC\src\hal"
-   )
-   IF NOT EXIST %target_directory%\BasicMAC\src\aes (
-      md "%target_directory%\BasicMAC\src\aes"
-   )
-   IF NOT EXIST %target_directory%\BasicMAC\examples (
-      md "%target_directory%\BasicMAC\examples"
-   )
-   IF NOT EXIST %target_directory%\BasicMAC\examples\basicmac-abp (
-      md "%target_directory%\BasicMAC\examples\basicmac-abp"
-   )
-   IF NOT EXIST %target_directory%\BasicMAC\examples\basicmac-otaa (
-      md "%target_directory%\BasicMAC\examples\basicmac-otaa"
-   )
+:DO_REMOVE
+:: remove existing directory, prompt for acknowledge.
+   ECHO Removing directory "%target_directory:"=%\BasicMAC",
+   SET /P AREYOUSURE=Are you sure (Y/[N])?
+   IF /I "%AREYOUSURE%" NEQ "Y" GOTO :EOF
    
+   rmdir /s /q "%target_directory:"=%\BasicMAC"
+
+:DO_CREATE
+:: Copy all files in to the library in the target directory
+   ECHO Ceating Arduino library in: "%target_directory:"=%"
+   IF NOT EXIST "%target_directory:"=%\BasicMAC" (
+      md "%target_directory:"=%\BasicMAC"
+   )
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\src" (
+      md "%target_directory:"=%\BasicMAC\src"
+   )
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\src\lmic" (
+      md "%target_directory:"=%\BasicMAC\src\lmic"
+   )
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\src\hal" (
+      md "%target_directory:"=%\BasicMAC\src\hal"
+   )
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\src\aes" (
+      md "%target_directory:"=%\BasicMAC\src\aes"
+   )
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\examples" (
+      md "%target_directory:"=%\BasicMAC\examples"
+   )
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\examples\basicmac-abp" (
+      md "%target_directory:"=%\BasicMAC\examples\basicmac-abp"
+   )
+   IF NOT EXIST "%target_directory:"=%\BasicMAC\examples\basicmac-otaa" (
+      md "%target_directory:"=%\BasicMAC\examples\basicmac-otaa"
+   )
+
+:DO_COPY
+   :: Copy relevant files from git repository to Arduino Library
    @ECHO on
-   COPY "%source_directory%library.properties" "%target_directory%BasicMAC\library.properties"
-   COPY "%source_directory%basicmac.h" "%target_directory%BasicMAC\src"
-   COPY "%source_directory%..\..\lmic" "%target_directory%BasicMAC\src\lmic"
-   COPY "%source_directory%hal" "%target_directory%BasicMAC\src\hal"
-   COPY "%source_directory%..\..\aes" "%target_directory%BasicMAC\src\aes"
-   COPY "%source_directory%examples\basicmac-otaa" "%target_directory%BasicMAC\examples\basicmac-otaa"
-   COPY "%source_directory%examples-common-files" "%target_directory%BasicMAC\examples\basicmac-otaa"
-   COPY "%source_directory%examples\basicmac-abp" "%target_directory%BasicMAC\examples\basicmac-abp"
-   COPY "%source_directory%examples-common-files" "%target_directory%BasicMAC\examples\basicmac-abp"
-   COPY "%source_directory%board.h" "%target_directory%BasicMAC\src\lmic"
-   COPY "%source_directory%hw.h" "%target_directory%BasicMAC\src\lmic"
+   COPY "%source_directory%library.properties" "%target_directory:"=%\BasicMAC\library.properties"
+   COPY "%source_directory%basicmac.h" "%target_directory:"=%\BasicMAC\src"
+   COPY "%source_directory%..\..\lmic" "%target_directory:"=%\BasicMAC\src\lmic"
+   COPY "%source_directory%hal" "%target_directory:"=%\BasicMAC\src\hal"
+   COPY "%source_directory%..\..\aes" "%target_directory:"=%\BasicMAC\src\aes"
+   COPY "%source_directory%examples\basicmac-otaa" "%target_directory:"=%\BasicMAC\examples\basicmac-otaa"
+   COPY "%source_directory%examples-common-files" "%target_directory:"=%\BasicMAC\examples\basicmac-otaa"
+   COPY "%source_directory%examples\basicmac-abp" "%target_directory:"=%\BasicMAC\examples\basicmac-abp"
+   COPY "%source_directory%examples-common-files" "%target_directory:"=%\BasicMAC\examples\basicmac-abp"
+   COPY "%source_directory%board.h" "%target_directory:"=%\BasicMAC\src\lmic"
+   COPY "%source_directory%hw.h" "%target_directory:"=%\BasicMAC\src\lmic"
    @ECHO off
 GOTO :EOF

--- a/target/arduino/export.bat
+++ b/target/arduino/export.bat
@@ -5,18 +5,22 @@
 
 :: Options are: 
 ::  -h  --help    Help and information.
-::  -c  --create  ^<directory^> Create Arduino library at specified location.
-::                              When a directory is found with equal name the 
-::                              user is informed and the script is aborted.
-::  -r  --replace ^<directory^> Replace Arduino library at specified location erasing existing files.
-::                              When a directory is found with equal name the 
-::                              user is requested to confirm deletion of the directory.
 
 :: \name Remko Welling (pe1mew@gmail.com)
 
 SET option=%1
 SET source_directory=%~dp0
-SET target_directory=%2
+
+:: Select operation: "-" is command, else run
+IF  "%option:~0,1%"=="-" (
+   GOTO :CASE
+) ELSE (
+   GOTO :RUN
+)
+GOTO :EOF
+
+:CASE
+:: Command handeling
 
 2>NUL CALL :CASE_%option% 
 
@@ -24,87 +28,78 @@ IF ERRORLEVEL 1 CALL :DEFAULT_CASE
 
 EXIT /B
 
-:CASE_-r
-:CASE_--replace
-:: remove existing folder structure and copy new library at specified location.
-   IF EXIST "%target_directory:"=%\BasicMAC" (
-      GOTO :DO_REMOVE
-   ) ELSE (
-      ECHO [ERROR] Destination directory "%target_directory:"=%\BasicMAC" does not exist. Please correct destination name.
-   )
+:CASE_-h
+:CASE_--help
+   ECHO Create an Arduino-compatible library in the given directory, overwriting existing files.
+   ECHO -h  --help    This information.
 GOTO :EOF
 
-:CASE_-c
-:CASE_--create
-:: create the directory and copy files to it, aborting if it already exists.
-   IF EXIST "%target_directory:"=%\BasicMAC" (
-      ECHO [ERROR] Destination directory "%target_directory:"=%\BasicMAC" does exist. Please correct destination name.
+:DEFAULT_CASE
+   ECHO Unknown command. Type: export.bat -h or --help for options.
+GOTO :EOF
+
+:RUN
+:: Normal operation.
+   IF NOT EXIST "%option:"=%" (
+      ECHO Target directory "%option:"=%" does not exist.
+      GOTO :EOF
+   ) 
+   IF EXIST "%option:"=%\BasicMAC" (
+      GOTO :DO_REMOVE
    ) ELSE (
       GOTO :DO_CREATE
    )
 GOTO :EOF
 
-:CASE_-h
-:CASE_--help
-   ECHO Create an Arduino-compatible library in the given directory, overwriting existing files.
-   ECHO -h  --help    This information.
-   ECHO -c  --create  ^<directory^> Create Arduino library at specified location.
-   ECHO -r  --replace ^<directory^> Replace Arduino library at specified location erasing existing files.
-GOTO :EOF
-
-:DEFAULT_CASE
-   ECHO Unknown command or abort. Type: export.bat -h or --help for options.
-GOTO :EOF
-
 :DO_REMOVE
-:: remove existing directory, prompt for acknowledge.
-   ECHO Removing directory "%target_directory:"=%\BasicMAC",
+:: Remove existing directory, prompt for acknowledge.
+   ECHO Removing directory "%option:"=%\BasicMAC",
    SET /P AREYOUSURE=Are you sure (Y/[N])?
    IF /I "%AREYOUSURE%" NEQ "Y" GOTO :EOF
    
-   rmdir /s /q "%target_directory:"=%\BasicMAC"
+   rmdir /s /q "%option:"=%\BasicMAC"
 
 :DO_CREATE
-:: Copy all files in to the library in the target directory
-   ECHO Ceating Arduino library in: "%target_directory:"=%"
-   IF NOT EXIST "%target_directory:"=%\BasicMAC" (
-      md "%target_directory:"=%\BasicMAC"
+:: Create directory structure for library in target directory
+   ECHO Ceating Arduino library in: "%option:"=%"
+   IF NOT EXIST "%option:"=%\BasicMAC" (
+      md "%option:"=%\BasicMAC"
    )
-   IF NOT EXIST "%target_directory:"=%\BasicMAC\src" (
-      md "%target_directory:"=%\BasicMAC\src"
+   IF NOT EXIST "%option:"=%\BasicMAC\src" (
+      md "%option:"=%\BasicMAC\src"
    )
-   IF NOT EXIST "%target_directory:"=%\BasicMAC\src\lmic" (
-      md "%target_directory:"=%\BasicMAC\src\lmic"
+   IF NOT EXIST "%option:"=%\BasicMAC\src\lmic" (
+      md "%option:"=%\BasicMAC\src\lmic"
    )
-   IF NOT EXIST "%target_directory:"=%\BasicMAC\src\hal" (
-      md "%target_directory:"=%\BasicMAC\src\hal"
+   IF NOT EXIST "%option:"=%\BasicMAC\src\hal" (
+      md "%option:"=%\BasicMAC\src\hal"
    )
-   IF NOT EXIST "%target_directory:"=%\BasicMAC\src\aes" (
-      md "%target_directory:"=%\BasicMAC\src\aes"
+   IF NOT EXIST "%option:"=%\BasicMAC\src\aes" (
+      md "%option:"=%\BasicMAC\src\aes"
    )
-   IF NOT EXIST "%target_directory:"=%\BasicMAC\examples" (
-      md "%target_directory:"=%\BasicMAC\examples"
+   IF NOT EXIST "%option:"=%\BasicMAC\examples" (
+      md "%option:"=%\BasicMAC\examples"
    )
-   IF NOT EXIST "%target_directory:"=%\BasicMAC\examples\basicmac-abp" (
-      md "%target_directory:"=%\BasicMAC\examples\basicmac-abp"
+   IF NOT EXIST "%option:"=%\BasicMAC\examples\basicmac-abp" (
+      md "%option:"=%\BasicMAC\examples\basicmac-abp"
    )
-   IF NOT EXIST "%target_directory:"=%\BasicMAC\examples\basicmac-otaa" (
-      md "%target_directory:"=%\BasicMAC\examples\basicmac-otaa"
+   IF NOT EXIST "%option:"=%\BasicMAC\examples\basicmac-otaa" (
+      md "%option:"=%\BasicMAC\examples\basicmac-otaa"
    )
 
 :DO_COPY
    :: Copy relevant files from git repository to Arduino Library
    @ECHO on
-   COPY "%source_directory%library.properties" "%target_directory:"=%\BasicMAC\library.properties"
-   COPY "%source_directory%basicmac.h" "%target_directory:"=%\BasicMAC\src"
-   COPY "%source_directory%..\..\lmic" "%target_directory:"=%\BasicMAC\src\lmic"
-   COPY "%source_directory%hal" "%target_directory:"=%\BasicMAC\src\hal"
-   COPY "%source_directory%..\..\aes" "%target_directory:"=%\BasicMAC\src\aes"
-   COPY "%source_directory%examples\basicmac-otaa" "%target_directory:"=%\BasicMAC\examples\basicmac-otaa"
-   COPY "%source_directory%examples-common-files" "%target_directory:"=%\BasicMAC\examples\basicmac-otaa"
-   COPY "%source_directory%examples\basicmac-abp" "%target_directory:"=%\BasicMAC\examples\basicmac-abp"
-   COPY "%source_directory%examples-common-files" "%target_directory:"=%\BasicMAC\examples\basicmac-abp"
-   COPY "%source_directory%board.h" "%target_directory:"=%\BasicMAC\src\lmic"
-   COPY "%source_directory%hw.h" "%target_directory:"=%\BasicMAC\src\lmic"
+   COPY "%source_directory%library.properties" "%option:"=%\BasicMAC\library.properties"
+   COPY "%source_directory%basicmac.h" "%option:"=%\BasicMAC\src"
+   COPY "%source_directory%..\..\lmic" "%option:"=%\BasicMAC\src\lmic"
+   COPY "%source_directory%hal" "%option:"=%\BasicMAC\src\hal"
+   COPY "%source_directory%..\..\aes" "%option:"=%\BasicMAC\src\aes"
+   COPY "%source_directory%examples\basicmac-otaa" "%option:"=%\BasicMAC\examples\basicmac-otaa"
+   COPY "%source_directory%examples-common-files" "%option:"=%\BasicMAC\examples\basicmac-otaa"
+   COPY "%source_directory%examples\basicmac-abp" "%option:"=%\BasicMAC\examples\basicmac-abp"
+   COPY "%source_directory%examples-common-files" "%option:"=%\BasicMAC\examples\basicmac-abp"
+   COPY "%source_directory%board.h" "%option:"=%\BasicMAC\src\lmic"
+   COPY "%source_directory%hw.h" "%option:"=%\BasicMAC\src\lmic"
    @ECHO off
 GOTO :EOF

--- a/target/arduino/export.bat
+++ b/target/arduino/export.bat
@@ -1,0 +1,89 @@
+@ECHO off > nul
+:: Batch file to install BasicMAC from the git repository in to an
+:: existing Arduino installation by specifying the location of the 
+:: User library directory e.g.: "C:\Users\UserName\Documents\Arduino\libraries"
+
+:: \name Remko Welling (pe1mew@gmail.com)
+:: \date 8-7-2020
+:: \version 1.0
+
+:: \todo This script cannot work when whitespaces are in the directory path.
+:: As a workaround, export the library else where and move it in to the Arduino library directory.
+
+SET option=%1
+SET source_directory=%~dp0
+SET target_directory=%2
+
+2>NUL CALL :CASE_%option% 
+
+IF ERRORLEVEL 1 CALL :DEFAULT_CASE
+
+EXIT /B
+
+:CASE_-c
+:CASE_--create
+   IF EXIST %target_directory% (
+      GOTO :COPY
+   ) ELSE (
+      ECHO [ERROR] Destination directory %target_directory% does not exist. Please correct destination name.
+   )
+GOTO :EOF
+
+:CASE_-h
+:CASE_--help
+   ECHO Create an Arduino-compatible library in the given directory, overwriting existing files.
+   ECHO -h  --help   This information.
+   ECHO -c  --create ^<directory^> Create Arduino library at specified location
+GOTO :EOF
+
+:DEFAULT_CASE
+   ECHO Unknown command. Type: export.bat -h or --help for options.
+GOTO :EOF
+
+:COPY
+   :: Test if target directory has a terminating back-slash
+   IF NOT "%target_directory:~-1%"=="\" (
+      ECHO [ERROR] Target directory has no terminating "\" (back-slash^). Please correct target directory accordingly.
+      GOTO :EOF
+   )
+   :: Copy all files in to the library in the target directory
+   ECHO Ceating Arduino library in: %target_directory%
+   IF NOT EXIST %target_directory%\BasicMAC (
+      md "%target_directory%\BasicMAC"
+   )
+   IF NOT EXIST %target_directory%\BasicMAC\src (
+      md "%target_directory%\BasicMAC\src"
+   )
+   IF NOT EXIST %target_directory%\BasicMAC\src\lmic (
+      md "%target_directory%\BasicMAC\src\lmic"
+   )
+   IF NOT EXIST %target_directory%\BasicMAC\src\hal (
+      md "%target_directory%\BasicMAC\src\hal"
+   )
+   IF NOT EXIST %target_directory%\BasicMAC\src\aes (
+      md "%target_directory%\BasicMAC\src\aes"
+   )
+   IF NOT EXIST %target_directory%\BasicMAC\examples (
+      md "%target_directory%\BasicMAC\examples"
+   )
+   IF NOT EXIST %target_directory%\BasicMAC\examples\basicmac-abp (
+      md "%target_directory%\BasicMAC\examples\basicmac-abp"
+   )
+   IF NOT EXIST %target_directory%\BasicMAC\examples\basicmac-otaa (
+      md "%target_directory%\BasicMAC\examples\basicmac-otaa"
+   )
+   
+   @ECHO on
+   COPY "%source_directory%library.properties" "%target_directory%BasicMAC\library.properties"
+   COPY "%source_directory%basicmac.h" "%target_directory%BasicMAC\src"
+   COPY "%source_directory%..\..\lmic" "%target_directory%BasicMAC\src\lmic"
+   COPY "%source_directory%hal" "%target_directory%BasicMAC\src\hal"
+   COPY "%source_directory%..\..\aes" "%target_directory%BasicMAC\src\aes"
+   COPY "%source_directory%examples\basicmac-otaa" "%target_directory%BasicMAC\examples\basicmac-otaa"
+   COPY "%source_directory%examples-common-files" "%target_directory%BasicMAC\examples\basicmac-otaa"
+   COPY "%source_directory%examples\basicmac-abp" "%target_directory%BasicMAC\examples\basicmac-abp"
+   COPY "%source_directory%examples-common-files" "%target_directory%BasicMAC\examples\basicmac-abp"
+   COPY "%source_directory%board.h" "%target_directory%BasicMAC\src\lmic"
+   COPY "%source_directory%hw.h" "%target_directory%BasicMAC\src\lmic"
+   @ECHO off
+GOTO :EOF

--- a/target/arduino/export.bat
+++ b/target/arduino/export.bat
@@ -96,10 +96,7 @@ GOTO :EOF
    COPY "%source_directory%..\..\lmic" "%target_directory:"=%\BasicMAC\src\lmic"
    COPY "%source_directory%hal" "%target_directory:"=%\BasicMAC\src\hal"
    COPY "%source_directory%..\..\aes" "%target_directory:"=%\BasicMAC\src\aes"
-   COPY "%source_directory%examples\basicmac-otaa" "%target_directory:"=%\BasicMAC\examples\basicmac-otaa"
-   COPY "%source_directory%examples-common-files" "%target_directory:"=%\BasicMAC\examples\basicmac-otaa"
-   COPY "%source_directory%examples\basicmac-abp" "%target_directory:"=%\BasicMAC\examples\basicmac-abp"
-   COPY "%source_directory%examples-common-files" "%target_directory:"=%\BasicMAC\examples\basicmac-abp"
+   XCOPY "%source_directory%examples" "%target_directory:"=%\BasicMAC\examples" /E /y
    COPY "%source_directory%board.h" "%target_directory:"=%\BasicMAC\src\lmic"
    COPY "%source_directory%hw.h" "%target_directory:"=%\BasicMAC\src\lmic"
    @ECHO off


### PR DESCRIPTION
1. Added ARDUINO_TTGO_LoRa32_V1 board to standard-pinmaps.ino and verified operation to be working OK.
2. Added export batch script for use in Windows environments to extract Arduino compatible library, similar to the shell script that is already available. The batch script will work when no spaces are part of the directory path.