### PR TITLE
SX126x: Make using DIO2/DIO3 to control TXRX/TCXO optional

### DIFF
--- a/.github/workflows/compile-arduino-examples.yml
+++ b/.github/workflows/compile-arduino-examples.yml
@@ -21,6 +21,7 @@ jobs:
         transceiver:
           - BRD_sx1272_radio
           - BRD_sx1276_radio
+          - BRD_sx1261_radio
           - BRD_sx1262_radio
         include:
           # Older compilers (used by STM32 and ESP) seem to get confused

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ existing sketches. For full details, see the git changelog.
    your board uses SX1276 (the old default), you need to modify
    `target-config.h` in the library.
 
+ - 2020-07-14: On SX126x, DIO3 is no longer configured to control a TCXO
+   by default. If your board needs this, it must be explicitly enabled.
+   On Arduino, set the `tcxo` field of the pin map to
+   `LMIC_CONTROLLED_BY_DIO3`. With Makefile-based stm32, define
+   `LMIC_DIO3_CONTROLS_TCXO` on the compiler commandline.
+
 ### Relation to other projects
 
 BasicMAC is a privately developed fork of LMIC, which was released

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ existing sketches. For full details, see the git changelog.
    `LMIC_CONTROLLED_BY_DIO3`. With Makefile-based stm32, define
    `LMIC_DIO3_CONTROLS_TCXO` on the compiler commandline.
 
+ - 2020-07-14: On SX126x, DIO2 is no longer configured to control a TXRX
+   antenna switch by default. If your board needs this (most likely it
+   does), it must be explicitly enabled. On Arduino, set the `tx`
+   field of the pin map to `LMIC_CONTROLLED_BY_DIO2`. With
+   Makefile-based stm32, define `LMIC_DIO2_CONTROLS_TXRX` on the
+   compiler commandline.
+
 ### Relation to other projects
 
 BasicMAC is a privately developed fork of LMIC, which was released

--- a/lmic/hal.h
+++ b/lmic/hal.h
@@ -34,11 +34,13 @@ void hal_watchcount (int cnt);
 #define HAL_ANTSW_TX2  3
 void hal_ant_switch (u1_t val);
 
+#if defined(BRD_sx1272_radio) || defined(BRD_sx1276_radio)
 /*
  * control radio TCXO power (0=off, 1=on)
  * (return if TCXO is present and in use)
  */
 bool hal_pin_tcxo (u1_t val);
+#endif // defined(BRD_sx1272_radio) || defined(BRD_sx1276_radio)
 
 /*
  * control radio RST pin (0=low, 1=high, 2=floating)

--- a/lmic/hal.h
+++ b/lmic/hal.h
@@ -69,6 +69,13 @@ void hal_irqmask_set (int mask);
  * somehow?
  */
 bool hal_dio3_controls_tcxo (void);
+
+/*
+ * Returns true if DIO2 should control the RXTX switch.
+ * TODO: Reconsider this HAL function, maybe integrate with
+ * hal_ant_switch somehow?
+ */
+bool hal_dio2_controls_rxtx (void);
 #endif // defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
 
 /*

--- a/lmic/hal.h
+++ b/lmic/hal.h
@@ -62,6 +62,15 @@ void hal_pin_busy_wait (void);
 #define HAL_IRQMASK_DIO3 (1<<3)
 void hal_irqmask_set (int mask);
 
+#if defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
+/*
+ * Returns true if DIO3 should control the TCXO.
+ * TODO: Reconsider this HAL function, maybe integrate with hal_pin_tcxo
+ * somehow?
+ */
+bool hal_dio3_controls_tcxo (void);
+#endif // defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
+
 /*
  * drive radio NSS pin (on=low, off=high).
  */

--- a/lmic/radio-sx126x.c
+++ b/lmic/radio-sx126x.c
@@ -547,7 +547,8 @@ void radio_sleep (void) {
 static void CommonSetup (void) {
     SetRegulatorMode(REGMODE_DCDC);
     SetDIO2AsRfSwitchCtrl(1);
-    SetDIO3AsTcxoCtrl();
+    if (hal_dio3_controls_tcxo())
+        SetDIO3AsTcxoCtrl();
 }
 
 static void txlora (void) {

--- a/lmic/radio-sx126x.c
+++ b/lmic/radio-sx126x.c
@@ -546,7 +546,8 @@ void radio_sleep (void) {
 // Do config common to all RF modes
 static void CommonSetup (void) {
     SetRegulatorMode(REGMODE_DCDC);
-    SetDIO2AsRfSwitchCtrl(1);
+    if (hal_dio2_controls_rxtx())
+        SetDIO2AsRfSwitchCtrl(1);
     if (hal_dio3_controls_tcxo())
         SetDIO3AsTcxoCtrl();
 }

--- a/lmic/radio.c
+++ b/lmic/radio.c
@@ -26,8 +26,11 @@ static void radio_stop (void) {
     radio_sleep();
     // disable antenna switch
     hal_ant_switch(HAL_ANTSW_OFF);
+#if defined(BRD_sx1272_radio) || defined(BRD_sx1276_radio)
     // power-down TCXO
     hal_pin_tcxo(0);
+#endif // defined(BRD_sx1272_radio) || defined(BRD_sx1276_radio)
+    // disable antenna switch
     // disable IRQs in HAL
     hal_irqmask_set(0);
     // cancel radio job

--- a/stm32/hal.c
+++ b/stm32/hal.c
@@ -738,6 +738,7 @@ static void hal_io_init () {
 #endif
 }
 
+#if defined(BRD_sx1272_radio) || defined(BRD_sx1276_radio)
 bool hal_pin_tcxo (u1_t val) {
 #if defined(GPIO_TCXO_PWR)
     if (val != 0) {
@@ -752,6 +753,7 @@ bool hal_pin_tcxo (u1_t val) {
     return false;
 #endif
 }
+#endif // defined(BRD_sx1272_radio) || defined(BRD_sx1276_radio)
 
 void hal_ant_switch (u1_t val) {
 #ifdef SVC_pwrman

--- a/stm32/hal.c
+++ b/stm32/hal.c
@@ -816,6 +816,16 @@ void hal_pin_busy_wait (void) {
 #endif
 }
 
+#if defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
+bool hal_dio3_controls_tcxo (void) {
+    #if defined(LMIC_DIO3_CONTROLS_TCXO)
+    return true;
+    #else
+    return false;
+    #endif
+}
+#endif // defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
+
 #define DIO_UPDATE(dio,mask,time) do { \
     if( (EXTI->PR & (1 << BRD_PIN(GPIO_DIO ## dio))) ) { \
         EXTI->PR = (1 << BRD_PIN(GPIO_DIO ## dio)); \

--- a/stm32/hal.c
+++ b/stm32/hal.c
@@ -824,6 +824,14 @@ bool hal_dio3_controls_tcxo (void) {
     return false;
     #endif
 }
+
+bool hal_dio2_controls_rxtx (void) {
+    #if defined(LMIC_DIO2_CONTROLS_RXTX)
+    return true;
+    #else
+    return false;
+    #endif
+}
 #endif // defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
 
 #define DIO_UPDATE(dio,mask,time) do { \

--- a/target/arduino/examples-common-files/standard-pinmaps.ino
+++ b/target/arduino/examples-common-files/standard-pinmaps.ino
@@ -78,8 +78,7 @@ const lmic_pinmap lmic_pins = {
 // This uses E22_* constants from the board variant file
 const lmic_pinmap lmic_pins = {
     .nss = E22_NSS, // PD2
-    // TXEN is controlled through DIO2 by the SX1262 directly
-    .tx = LMIC_UNUSED_PIN,
+    .tx = LMIC_CONTROLLED_BY_DIO2,
     .rx = E22_RXEN, // PC4
     .rst = E22_NRST, // PA4
     .dio = {LMIC_UNUSED_PIN, E22_DIO1 /* PC7 */, LMIC_UNUSED_PIN},

--- a/target/arduino/examples-common-files/standard-pinmaps.ino
+++ b/target/arduino/examples-common-files/standard-pinmaps.ino
@@ -84,8 +84,7 @@ const lmic_pinmap lmic_pins = {
     .rst = E22_NRST, // PA4
     .dio = {LMIC_UNUSED_PIN, E22_DIO1 /* PC7 */, LMIC_UNUSED_PIN},
     .busy = E22_BUSY, // PB12
-    // TCXO is controlled through DIO3 by the SX1262 directly
-    .tcxo = LMIC_UNUSED_PIN,
+    .tcxo = LMIC_CONTROLLED_BY_DIO3,
 };
 #else
 #error "Unknown board, no standard pimap available. Define your own in the main sketch file."

--- a/target/arduino/examples/basicmac-abp/basicmac-abp.ino
+++ b/target/arduino/examples/basicmac-abp/basicmac-abp.ino
@@ -72,9 +72,17 @@ const lmic_pinmap lmic_pins = {
     // If needed, these pins control the RX/TX antenna switch (active
     // high outputs). When you have both, the antenna switch can
     // powerdown when unused. If you just have a RXTX pin it should
-    // usually be set to .tx, reverting to RX mode when idle).
-    // Often, the antenna switch is controlled directly by the radio
-    // chip, through is RXTX (SX127x) or DIO2 (SX126x) output pins.
+    // usually be assigned to .tx, reverting to RX mode when idle).
+    //
+    // The SX127x has an RXTX pin that can automatically control the
+    // antenna switch (if internally connected on the transceiver
+    // board). This pin is always active, so no configuration is needed
+    // for that here.
+    // On SX126x, the DIO2 can be used for the same thing, but this is
+    // disabled by default. To enable this, set .tx to
+    // LMIC_CONTROLLED_BY_DIO2 below (this seems to be common and
+    // enabling it when not needed is probably harmless, unless DIO2 is
+    // connected to GND or VCC directly inside the transceiver board).
     .tx = LMIC_UNUSED_PIN,
     .rx = LMIC_UNUSED_PIN,
     // Radio reset output pin (active high for SX1276, active low for

--- a/target/arduino/examples/basicmac-abp/basicmac-abp.ino
+++ b/target/arduino/examples/basicmac-abp/basicmac-abp.ino
@@ -88,7 +88,15 @@ const lmic_pinmap lmic_pins = {
     // cause problems.
     .busy = LMIC_UNUSED_PIN,
     // TCXO oscillator enable output pin (active high).
-    // The SX126x can control the TCXO directly through its DIO3 output pin.
+    //
+    // For SX127x this should be an I/O pin that controls the TCXO, or
+    // LMIC_UNUSED_PIN when a crystal is used instead of a TCXO.
+    //
+    // For SX126x this should be LMIC_CONTROLLED_BY_DIO3 when a TCXO is
+    // directly connected to the transceiver DIO3 to let the transceiver
+    // start and stop the TCXO, or LMIC_UNUSED_PIN when a crystal is
+    // used instead of a TCXO. Controlling the TCXO from the MCU is not
+    // supported.
     .tcxo = LMIC_UNUSED_PIN,
 };
 #endif // !defined(USE_STANDARD_PINMAP)

--- a/target/arduino/examples/basicmac-otaa/basicmac-otaa.ino
+++ b/target/arduino/examples/basicmac-otaa/basicmac-otaa.ino
@@ -91,7 +91,15 @@ const lmic_pinmap lmic_pins = {
     // cause problems.
     .busy = LMIC_UNUSED_PIN,
     // TCXO oscillator enable output pin (active high).
-    // The SX126x can control the TCXO directly through its DIO3 output pin.
+    //
+    // For SX127x this should be an I/O pin that controls the TCXO, or
+    // LMIC_UNUSED_PIN when a crystal is used instead of a TCXO.
+    //
+    // For SX126x this should be LMIC_CONTROLLED_BY_DIO3 when a TCXO is
+    // directly connected to the transceiver DIO3 to let the transceiver
+    // start and stop the TCXO, or LMIC_UNUSED_PIN when a crystal is
+    // used instead of a TCXO. Controlling the TCXO from the MCU is not
+    // supported.
     .tcxo = LMIC_UNUSED_PIN,
 };
 #endif // !defined(USE_STANDARD_PINMAP)

--- a/target/arduino/hal/hal.cpp
+++ b/target/arduino/hal/hal.cpp
@@ -49,6 +49,10 @@ static void hal_io_init () {
     ASSERT(lmic_pins.busy != LMIC_UNUSED_PIN);
 #endif
 
+#if !defined(BRD_sx1272_radio) && !defined(BRD_sx1276_radio)
+    ASSERT(lmic_pins.tcxo == LMIC_UNUSED_PIN);
+#endif
+
     // Write HIGH to deselect (NSS is active low). Do this before
     // setting output, to prevent a moment of OUTPUT LOW on e.g. AVR.
     digitalWrite(lmic_pins.nss, HIGH);
@@ -117,6 +121,7 @@ static void hal_io_check() {
     }
 }
 
+#if defined(BRD_sx1272_radio) || defined(BRD_sx1276_radio)
 bool hal_pin_tcxo (u1_t val) {
     if (lmic_pins.tcxo == LMIC_UNUSED_PIN)
         return false;
@@ -124,6 +129,7 @@ bool hal_pin_tcxo (u1_t val) {
     digitalWrite(lmic_pins.tcxo, val);
     return true;
 }
+#endif // defined(BRD_sx1272_radio) || defined(BRD_sx1276_radio)
 
 void hal_pin_busy_wait (void) {
     if (lmic_pins.busy == LMIC_UNUSED_PIN) {

--- a/target/arduino/hal/hal.cpp
+++ b/target/arduino/hal/hal.cpp
@@ -33,12 +33,12 @@ static void hal_io_init () {
     // Checks below assume that all special pin values are >= LMIC_UNUSED_PIN, so check that.
     #if defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
     LMIC_STATIC_ASSERT(LMIC_UNUSED_PIN < LMIC_CONTROLLED_BY_DIO3, "Unexpected constant values");
+    LMIC_STATIC_ASSERT(LMIC_UNUSED_PIN < LMIC_CONTROLLED_BY_DIO2, "Unexpected constant values");
     #endif // defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
 
     ASSERT(lmic_pins.nss < LMIC_UNUSED_PIN);
     ASSERT(lmic_pins.rst <= LMIC_UNUSED_PIN);
     ASSERT(lmic_pins.rx <= LMIC_UNUSED_PIN);
-    ASSERT(lmic_pins.tx <= LMIC_UNUSED_PIN);
 
 #if defined(BRD_sx1272_radio) || defined(BRD_sx1276_radio)
     //DIO0 is required, DIO1 is required for LoRa, DIO2 for FSK
@@ -47,6 +47,7 @@ static void hal_io_init () {
 
     ASSERT(lmic_pins.busy == LMIC_UNUSED_PIN);
     ASSERT(lmic_pins.tcxo == LMIC_UNUSED_PIN);
+    ASSERT(lmic_pins.tx <= LMIC_UNUSED_PIN);
 #elif defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
     // Only DIO1 should be specified
     ASSERT(lmic_pins.dio[0] == LMIC_UNUSED_PIN);
@@ -55,6 +56,7 @@ static void hal_io_init () {
 
     ASSERT(lmic_pins.busy <= LMIC_UNUSED_PIN);
     ASSERT(lmic_pins.tcxo == LMIC_UNUSED_PIN || lmic_pins.tcxo == LMIC_CONTROLLED_BY_DIO3);
+    ASSERT(lmic_pins.tx <= LMIC_UNUSED_PIN || lmic_pins.tx == LMIC_CONTROLLED_BY_DIO2);
 #else
     #error "Unknown radio type?"
 #endif
@@ -156,6 +158,9 @@ void hal_pin_busy_wait (void) {
 #if defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
 bool hal_dio3_controls_tcxo (void) {
     return lmic_pins.tcxo == LMIC_CONTROLLED_BY_DIO3;
+}
+bool hal_dio2_controls_rxtx (void) {
+    return lmic_pins.tx == LMIC_CONTROLLED_BY_DIO2;
 }
 #endif // defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
 

--- a/target/arduino/hal/hal.cpp
+++ b/target/arduino/hal/hal.cpp
@@ -53,7 +53,7 @@ static void hal_io_init () {
     ASSERT(lmic_pins.dio[1] < LMIC_UNUSED_PIN);
     ASSERT(lmic_pins.dio[2] == LMIC_UNUSED_PIN);
 
-    ASSERT(lmic_pins.busy < LMIC_UNUSED_PIN);
+    ASSERT(lmic_pins.busy <= LMIC_UNUSED_PIN);
     ASSERT(lmic_pins.tcxo == LMIC_UNUSED_PIN || lmic_pins.tcxo == LMIC_CONTROLLED_BY_DIO3);
 #else
     #error "Unknown radio type?"

--- a/target/arduino/hal/hal.cpp
+++ b/target/arduino/hal/hal.cpp
@@ -51,6 +51,8 @@ static void hal_io_init () {
 
 #if !defined(BRD_sx1272_radio) && !defined(BRD_sx1276_radio)
     ASSERT(lmic_pins.tcxo == LMIC_UNUSED_PIN);
+#else
+    ASSERT(lmic_pins.tcxo == LMIC_UNUSED_PIN || lmic_pins.tcxo == LMIC_CONTROLLED_BY_DIO3);
 #endif
 
     // Write HIGH to deselect (NSS is active low). Do this before
@@ -146,6 +148,12 @@ void hal_pin_busy_wait (void) {
         while((micros() - start) < MAX_BUSY_TIME && digitalRead(lmic_pins.busy)) /* wait */;
     }
 }
+
+#if defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
+bool hal_dio3_controls_tcxo (void) {
+    return lmic_pins.tcxo == LMIC_CONTROLLED_BY_DIO3;
+}
+#endif // defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
 
 // -----------------------------------------------------------------------------
 // SPI

--- a/target/arduino/hal/hal.h
+++ b/target/arduino/hal/hal.h
@@ -28,11 +28,12 @@ struct lmic_pinmap {
 };
 
 // Use this for any unused pins.
-const u1_t LMIC_UNUSED_PIN = 0xfe;
+const u1_t LMIC_UNUSED_PIN = 0xfd;
 
 #if defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
 // Used for lmic_pinmap.tcxo only
 const u1_t LMIC_CONTROLLED_BY_DIO3 = 0xff;
+const u1_t LMIC_CONTROLLED_BY_DIO2 = 0xfe;
 #endif // defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
 
 // Declared here, to be defined an initialized by the application

--- a/target/arduino/hal/hal.h
+++ b/target/arduino/hal/hal.h
@@ -28,7 +28,12 @@ struct lmic_pinmap {
 };
 
 // Use this for any unused pins.
-const u1_t LMIC_UNUSED_PIN = 0xff;
+const u1_t LMIC_UNUSED_PIN = 0xfe;
+
+#if defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
+// Used for lmic_pinmap.tcxo only
+const u1_t LMIC_CONTROLLED_BY_DIO3 = 0xff;
+#endif // defined(BRD_sx1261_radio) || defined(BRD_sx1262_radio)
 
 // Declared here, to be defined an initialized by the application
 extern const lmic_pinmap lmic_pins;


### PR DESCRIPTION
This fixes #9 by making DIO3 control optional.

This is a breaking change (the default changes, boards with a TCXO now need to change their pinmaps), as documented in the README.

See commit messages for details.