### PR TITLE
arduino: Fix export script when path contains whitespace

### DIFF
--- a/target/arduino/export.sh
+++ b/target/arduino/export.sh
@@ -43,10 +43,10 @@ usage() {
 # This recursively copies $1 (file or directory) into $2 (directory)
 # This is essentially cp --symbolic-link, but POSIX-compatible.
 create_links() {
-	local TARGET=$(cd "$2" && pwd)
-	local SRCDIR=$(cd "$(dirname "$1")" && pwd)
-	local SRCNAME=$(basename "$1")
-	(cd "$SRCDIR" && find "$SRCNAME" -type d -exec mkdir -p "$TARGET/{}" \; -o -exec ln -s -v "$SRCDIR/{}" "$TARGET/{}" \; )
+	LINK_TARGET=$(cd "$2" && pwd)
+	LINK_SRCDIR=$(cd "$(dirname "$1")" && pwd)
+	LINK_SRCNAME=$(basename "$1")
+	(cd "$LINK_SRCDIR" && find "$LINK_SRCNAME" -type d -exec mkdir -p "$LINK_TARGET/{}" \; -o -exec ln -s -v "$LINK_SRCDIR/{}" "$LINK_TARGET/{}" \; )
 }
 
 


### PR DESCRIPTION
Because of the way the `local` keyword works in shells and missing
quotes, when using `--link` and having a space in either the clone
directory or export target directory, the script would error out.

But it also turns out that POSIX sh does not actually specify the local
keyword. Even though most implementations seem to support it, using
local variables is not quite essential here, so better improve
compatibility and use global variables instead (which, due to the way a
normal assignment interacts with word-splitting, does not suffer from
the same problem even without quotes).

This fixes #21.